### PR TITLE
MNT-96: Add basic tests for services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,7 @@ update:
 	uv sync --all-extras --dev
 	uv run pre-commit autoupdate
 
-ci: install check
+ci: install check test
+
+test:
+	uv run pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pytest>=8.3.0",
     "uv-bump>=0.5.0",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_redis_client() -> MagicMock:
+    client = MagicMock()
+    client.get.return_value = None
+    client.keys.return_value = []
+    return client

--- a/tests/test_autodelete.py
+++ b/tests/test_autodelete.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock, patch
+
+from mgallery.autodelete import run_autodelete
+
+
+class TestRunAutodelete:
+    @patch("mgallery.autodelete.Database")
+    @patch("mgallery.autodelete.os")
+    def test_run_autodelete_deletes_duplicates(self, mock_os, mock_db_class):
+        mock_db = MagicMock()
+        mock_db.duplicates.return_value = {"abc123": [{"path": "test", "name": "img1.jpg", "size": 1000}, {"path": "test", "name": "img2.jpg", "size": 500}]}
+        mock_db_class.return_value = mock_db
+        mock_os.path.exists.return_value = True
+        run_autodelete()
+        assert mock_db.delete.call_count == 1
+
+    @patch("mgallery.autodelete.Database")
+    @patch("mgallery.autodelete.os")
+    def test_run_autodelete_removes_thumbnail(self, mock_os, mock_db_class):
+        mock_db = MagicMock()
+        mock_db.duplicates.return_value = {"abc123": [{"path": "test", "name": "img1.jpg", "size": 1000}, {"path": "test", "name": "img2.jpg", "size": 500}]}
+        mock_db_class.return_value = mock_db
+        mock_os.path.exists.side_effect = [True, True]
+        mock_os.remove = MagicMock()
+        run_autodelete()
+        assert mock_os.remove.call_count == 2

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,71 @@
+import json
+from unittest.mock import patch
+
+from mgallery.database import Database
+
+
+class TestDatabase:
+    def test_database_init(self, mock_redis_client):
+        with patch("mgallery.database.redis") as mock_redis:
+            mock_redis.from_url.return_value = mock_redis_client
+            Database()
+            mock_redis.from_url.assert_called_once()
+
+    def test_get_returns_dict(self, mock_redis_client):
+        mock_redis_client.get.return_value = json.dumps({"key": "value"}).encode()
+        with patch("mgallery.database.redis") as mock_redis:
+            mock_redis.from_url.return_value = mock_redis_client
+            db = Database()
+            result = db.get("test_key")
+            assert result == {"key": "value"}
+
+    def test_get_returns_empty_dict_when_not_found(self, mock_redis_client):
+        mock_redis_client.get.return_value = None
+        with patch("mgallery.database.redis") as mock_redis:
+            mock_redis.from_url.return_value = mock_redis_client
+            db = Database()
+            result = db.get("nonexistent_key")
+            assert result == {}
+
+    def test_all_returns_list(self, mock_redis_client):
+        mock_redis_client.keys.return_value = [b"key1", b"key2"]
+        mock_redis_client.get.side_effect = [json.dumps({"name": "img1"}).encode(), json.dumps({"name": "img2"}).encode()]
+        with patch("mgallery.database.redis") as mock_redis:
+            mock_redis.from_url.return_value = mock_redis_client
+            db = Database()
+            result = db.all()
+            assert len(result) == 2
+
+    def test_create(self, mock_redis_client):
+        with patch("mgallery.database.redis") as mock_redis:
+            mock_redis.from_url.return_value = mock_redis_client
+            db = Database()
+            db.create(path="test", name="image.jpg", phash="abc123", width=100, height=100, size=1000)
+            mock_redis_client.set.assert_called_once()
+
+    def test_delete(self, mock_redis_client):
+        mock_redis_client.keys.return_value = [b"key1"]
+        with patch("mgallery.database.redis") as mock_redis:
+            mock_redis.from_url.return_value = mock_redis_client
+            db = Database()
+            db.delete("test", "image.jpg")
+            mock_redis_client.keys.assert_called()
+            mock_redis_client.delete.assert_called_once()
+
+    def test_duplicates_returns_dict(self, mock_redis_client):
+        mock_redis_client.keys.return_value = [b"abc-test/img1", b"abc-test/img2"]
+        mock_redis_client.get.side_effect = [json.dumps({"path": "test", "name": "img1", "phash": "abc", "size": 1000}).encode(), json.dumps({"path": "test", "name": "img2", "phash": "abc", "size": 900}).encode()]
+        with patch("mgallery.database.redis") as mock_redis:
+            mock_redis.from_url.return_value = mock_redis_client
+            db = Database()
+            result = db.duplicates()
+            assert "abc" in result
+
+    def test_duplicates_filters_single_images(self, mock_redis_client):
+        mock_redis_client.keys.return_value = [b"abc-test/img1"]
+        mock_redis_client.get.return_value = json.dumps({"path": "test", "name": "img1", "phash": "abc"}).encode()
+        with patch("mgallery.database.redis") as mock_redis:
+            mock_redis.from_url.return_value = mock_redis_client
+            db = Database()
+            result = db.duplicates()
+            assert result == {}

--- a/tests/test_date_re.py
+++ b/tests/test_date_re.py
@@ -1,0 +1,45 @@
+import re
+
+from mgallery.date_re import DATE_PARSERS, date_compiler_01, date_compiler_02, date_compiler_03, date_compiler_04
+
+
+class TestDateCompiler01:
+    def test_january_30_2017_at_0733pm(self):
+        pattern = re.compile(r"(?P<month>\w*)_(?P<day>\d{2})__(?P<year>\d{4})_at_(?P<hours>\d{2})(?P<minutes>\d{2})(?P<ampm>\w{2}).*")
+        match = pattern.search("January_30__2017_at_0733PM.jpg")
+        assert match is not None
+        result = date_compiler_01(match)
+        assert result.year == 2017
+        assert result.month == 1
+
+class TestDateCompiler02:
+    def test_20171222_232414(self):
+        pattern = re.compile(r"(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})_(?P<hours>\d{2})(?P<minutes>\d{2})(?P<seconds>\d{2}).*")
+        match = pattern.search("20171222_232414.jpg")
+        assert match is not None
+        result = date_compiler_02(match)
+        assert result.year == 2017
+
+class TestDateCompiler03:
+    def test_p61126_233638(self):
+        pattern = re.compile(r"P(?P<year>\d)(?P<month>\d{2})(?P<day>\d{2})-(?P<hours>\d{2})(?P<minutes>\d{2})(?P<seconds>\d{2}).*")
+        match = pattern.search("P61126-233638.jpg")
+        assert match is not None
+        result = date_compiler_03(match)
+        assert result.year == 2016
+
+class TestDateCompiler04:
+    def test_img_20140803_075125(self):
+        pattern = re.compile(r"(IMG|VID|PANO)_(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})_(?P<hours>\d{2})(?P<minutes>\d{2})(?P<seconds>\d{2}).*")
+        match = pattern.search("IMG_20140803_075125.jpg")
+        assert match is not None
+        result = date_compiler_04(match)
+        assert result.year == 2014
+
+class TestDateParsers:
+    def test_date_parsers_not_empty(self):
+        assert len(DATE_PARSERS) == 4
+
+    def test_all_patterns_are_compiled(self):
+        for pattern in DATE_PARSERS.keys():
+            assert isinstance(pattern, re.Pattern)

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,0 +1,17 @@
+from unittest.mock import MagicMock, patch
+
+from mgallery.dump import run_dump
+
+
+class TestRunDump:
+    @patch("mgallery.dump.Database")
+    @patch("mgallery.dump.open", create=True)
+    def test_run_dump(self, mock_open, mock_db_class):
+        mock_db = MagicMock()
+        mock_db.all.return_value = [{"name": "img1"}, {"name": "img2"}]
+        mock_db_class.return_value = mock_db
+        mock_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file
+        run_dump()
+        mock_file.write.assert_called_once()
+        mock_db.all.assert_called_once()

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+from mgallery import image, settings
+
+
+class TestProcessRawImage:
+    @patch("mgallery.image.get_image_phash")
+    @patch("mgallery.image.rawpy")
+    @patch("mgallery.image.Database")
+    def test_process_raw_image_success(self, mock_db_class, mock_rawpy, mock_phash):
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+        mock_raw = MagicMock()
+        mock_raw.postprocess.return_value = MagicMock(shape=[1080, 1920, 3])
+        mock_rawpy.imread.return_value.__enter__.return_value = mock_raw
+        mock_phash.return_value = "abc123"
+        image.process_raw_image(mock_db, "test", "image.arw", 1024000)
+        mock_db.create.assert_called_once()
+
+class TestCreateThumbnail:
+    @patch("mgallery.image.os.path.exists")
+    @patch("mgallery.image.os.makedirs")
+    @patch("mgallery.image.Image")
+    @patch("mgallery.image.rawpy")
+    def test_create_thumbnail_no_force(self, mock_rawpy, mock_image_cls, mock_makedirs, mock_exists):
+        mock_exists.return_value = True
+        result = image.create_thumbnail("test", "image.jpg", size=128, force=False)
+        assert result.startswith(settings.THUMBNAILS_PATH)
+
+    @patch("mgallery.image.os.path.exists")
+    @patch("mgallery.image.os.makedirs")
+    @patch("mgallery.image.Image")
+    @patch("mgallery.image.rawpy")
+    def test_create_thumbnail_force(self, mock_rawpy, mock_image_cls, mock_makedirs, mock_exists):
+        mock_exists.return_value = True
+        mock_image = MagicMock()
+        mock_image_cls.open.return_value = mock_image
+        mock_image_cls.fromarray.return_value = mock_image
+        image.create_thumbnail("test", "image.jpg", size=128, force=True)
+        mock_image.save.assert_called_once()
+
+class TestProcessImage:
+    @patch("mgallery.image.os.path.getsize")
+    @patch("mgallery.image.process_rgb_image")
+    def test_process_image_jpg(self, mock_process_rgb, mock_getsize):
+        mock_getsize.return_value = 1024
+        mock_db = MagicMock()
+        image.process_image(mock_db, "test", "image.jpg")
+        mock_process_rgb.assert_called_once()
+
+    @patch("mgallery.image.os.path.getsize")
+    @patch("mgallery.image.process_raw_image")
+    def test_process_image_arw(self, mock_process_raw, mock_getsize):
+        mock_getsize.return_value = 1024
+        mock_db = MagicMock()
+        image.process_image(mock_db, "test", "image.arw")
+        mock_process_raw.assert_called_once()
+
+    @patch("mgallery.image.os.path.getsize")
+    @patch("mgallery.image.process_raw_image")
+    def test_process_image_dng(self, mock_process_raw, mock_getsize):
+        mock_getsize.return_value = 1024
+        mock_db = MagicMock()
+        image.process_image(mock_db, "test", "image.dng")
+        mock_process_raw.assert_called_once()

--- a/tests/test_phash.py
+++ b/tests/test_phash.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+import numpy as np
+
+from mgallery.phash import get_image_phash
+
+
+class TestGetImagePhash:
+    @patch("mgallery.phash.cv2")
+    @patch("mgallery.phash.numpy")
+    def test_get_image_phash_success(self, mock_numpy, mock_cv2):
+        mock_image = np.ones((24, 24, 3), dtype=np.uint8)
+        mock_numpy.asarray.return_value = mock_image
+        mock_numpy.float32.return_value = mock_image
+        mock_numpy.median.return_value = 100
+        dct_mock = np.zeros((6, 6))
+        dct_mock[0, 0] = 200
+        mock_cv2.dct.return_value = dct_mock
+        result = get_image_phash(mock_image)
+        assert result is not None
+        assert isinstance(result, str)
+
+    @patch("mgallery.phash.cv2")
+    @patch("mgallery.phash.numpy")
+    def test_get_image_phash_with_none_image(self, mock_numpy, mock_cv2):
+        mock_numpy.asarray.side_effect = ValueError("image is None")
+        mock_image = np.array([])
+        result = get_image_phash(mock_image)
+        assert result is None
+
+    @patch("mgallery.phash.cv2")
+    @patch("mgallery.phash.numpy")
+    def test_get_image_phash_with_wrong_size(self, mock_numpy, mock_cv2):
+        mock_image = np.ones((10, 10, 3), dtype=np.uint8)
+        mock_numpy.asarray.return_value = mock_image
+        mock_numpy.float32.return_value = mock_image
+        mock_cv2.resize.return_value = np.ones((24, 24), dtype=np.uint8)
+        dct_mock = np.zeros((6, 6))
+        mock_cv2.dct.return_value = dct_mock
+        mock_numpy.median.return_value = 100
+        result = get_image_phash(mock_image)
+        assert result is not None

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock, patch
+
+from mgallery.rename import get_datetime_from_exif, get_datetime_from_filename
+
+
+class TestGetDatetimeFromExif:
+    @patch("mgallery.rename.open", create=True)
+    @patch("mgallery.rename.exifread")
+    def test_get_datetime_from_exif_success(self, mock_exif, mock_file):
+        mock_exif.process_file.return_value = {"EXIF DateTimeOriginal": "2024:01:15 10:30:00"}
+        mock_file.return_value.__enter__.return_value.read = MagicMock()
+        result = get_datetime_from_exif("/path/to/image.jpg")
+        assert result is not None
+        assert result.year == 2024
+
+    @patch("mgallery.rename.open", create=True)
+    @patch("mgallery.rename.exifread")
+    def test_get_datetime_from_exif_no_exif(self, mock_exif, mock_file):
+        mock_exif.process_file.return_value = {}
+        mock_file.return_value.__enter__.return_value.read = MagicMock()
+        result = get_datetime_from_exif("/path/to/image.jpg")
+        assert result is None
+
+class TestGetDatetimeFromFilename:
+    def test_get_datetime_from_filename_img_format(self):
+        result = get_datetime_from_filename("IMG_20140803_075125.jpg")
+        assert result is not None
+        assert result.year == 2014
+
+    def test_get_datetime_from_filename_no_match(self):
+        result = get_datetime_from_filename("random_file_name.jpg")
+        assert result is None

--- a/tests/test_resort.py
+++ b/tests/test_resort.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mgallery.resort import get_path_from_filename, month_to_season
+
+
+class TestMonthToSeason:
+    @pytest.mark.parametrize("month,expected", [(1, "Зима"), (2, "Зима"), (12, "Зима"), (3, "Весна"), (4, "Весна"), (5, "Весна"), (6, "Лето"), (7, "Лето"), (8, "Лето"), (9, "Осень"), (10, "Осень"), (11, "Осень")])
+    def test_month_to_season(self, month, expected):
+        result = month_to_season(month)
+        assert result == expected
+
+class TestGetPathFromFilename:
+    def test_get_path_from_filename_winter(self):
+        result = get_path_from_filename("2024-01-15_10-30-00.jpg")
+        gallery, date, _ = result
+        assert gallery == "2024 Зима"
+        assert date == "2024-01-15"
+
+class TestRunResort:
+    @patch("mgallery.resort.get_gallery_file_list")
+    @patch("mgallery.resort.Path")
+    def test_run_resort(self, mock_path_cls, mock_get_files):
+        mock_get_files.return_value = []
+        mock_path_cls.return_value.mkdir = MagicMock()
+        from mgallery.resort import run_resort
+        run_resort()
+        mock_get_files.assert_called_once()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+from mgallery.scanner import get_file_chunks
+
+
+class TestGetFileChunks:
+    @patch("mgallery.scanner.get_gallery_file_list")
+    def test_get_file_chunks_empty(self, mock_get_files):
+        mock_get_files.return_value = []
+        result = get_file_chunks(num_cores=2)
+        assert isinstance(result, list)
+
+    @patch("mgallery.scanner.get_gallery_file_list")
+    def test_get_file_chunks_single_file(self, mock_get_files):
+        mock_get_files.return_value = ["/path/to/image.jpg"]
+        result = get_file_chunks(num_cores=1)
+        assert len(result) == 1
+
+    @patch("mgallery.scanner.get_gallery_file_list")
+    def test_get_file_chunks_multiple_files(self, mock_get_files):
+        mock_get_files.return_value = [f"/path/to/image{i}.jpg" for i in range(10)]
+        result = get_file_chunks(num_cores=2)
+        total_files = sum(len(chunk) for chunk in result)
+        assert total_files == 10

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,23 @@
+def test_thumbnails_path_set():
+    from mgallery import settings
+    assert settings.THUMBNAILS_PATH
+
+def test_redis_url_set():
+    from mgallery import settings
+    assert settings.REDIS_URL
+
+def test_file_types():
+    from mgallery import settings
+    expected = ("arw", "dng", "jpg", "jpeg", "png", "webp", "gif")
+    assert settings.FILE_TYPES == expected
+
+def test_num_processes():
+    from mgallery import settings
+    assert settings.NUM_PROCESSES >= 0
+
+def test_logging_config():
+    from mgallery import settings
+    logging = settings.LOGGING
+    assert logging["version"] == 1
+    handlers = logging.get("handlers", {})
+    assert isinstance(handlers, dict)

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock, patch
+
+from mgallery.thumbnails import create_thumbnails, get_duplicates_chunks
+
+
+class TestGetDuplicatesChunks:
+    @patch("mgallery.thumbnails.Database")
+    def test_get_duplicates_chunks_empty(self, mock_db_class):
+        mock_db = MagicMock()
+        mock_db.duplicates.return_value = {}
+        mock_db_class.return_value = mock_db
+        result = get_duplicates_chunks(num_cores=1)
+        assert isinstance(result, list)
+
+    @patch("mgallery.thumbnails.Database")
+    def test_get_duplicates_chunks_with_duplicates(self, mock_db_class):
+        mock_db = MagicMock()
+        mock_db.duplicates.return_value = {"abc": [{"name": "img1"}, {"name": "img2"}]}
+        mock_db_class.return_value = mock_db
+        result = get_duplicates_chunks(num_cores=1)
+        assert isinstance(result, list)
+
+class TestCreateThumbnails:
+    @patch("mgallery.thumbnails.create_thumbnail")
+    def test_create_thumbnails_skips_gif(self, mock_create_thumbnail):
+        duplicates = {"abc": [{"path": "test", "name": "image.gif"}, {"path": "test", "name": "image.jpg"}]}
+        create_thumbnails(duplicates, 0)
+        assert mock_create_thumbnail.call_count == 1
+
+    @patch("mgallery.thumbnails.create_thumbnail")
+    def test_create_thumbnails_calls_create(self, mock_create_thumbnail):
+        duplicates = {"abc": [{"path": "test", "name": "image1.jpg"}, {"path": "test", "name": "image2.jpg"}]}
+        create_thumbnails(duplicates, 0)
+        assert mock_create_thumbnail.call_count == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+
+from mgallery.utils import binary_array_to_hex, get_gallery_file_list
+
+
+class TestBinaryArrayToHex:
+    def test_binary_array_to_hex_returns_string(self):
+        binary_array = [1] * 64
+        result = binary_array_to_hex(binary_array, hash_size=8)
+        assert isinstance(result, str)
+
+    def test_binary_array_to_hex_all_ones(self):
+        binary_array = [1] * 64
+        result = binary_array_to_hex(binary_array, hash_size=8)
+        assert result == "ffffffffffffffff"
+
+class TestGetGalleryFileList:
+    @patch("mgallery.utils.glob")
+    def test_get_gallery_file_list_empty(self, mock_glob):
+        mock_glob.glob.return_value = []
+        result = get_gallery_file_list(recursive=True)
+        assert result == []

--- a/uv.lock
+++ b/uv.lock
@@ -93,6 +93,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ipython"
 version = "9.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -173,6 +182,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "uv-bump" },
 ]
 
@@ -195,7 +205,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "uv-bump", specifier = ">=0.5.0" }]
+dev = [
+    { name = "pytest", specifier = ">=8.3.0" },
+    { name = "uv-bump", specifier = ">=0.5.0" },
+]
 
 [[package]]
 name = "nodeenv"
@@ -251,6 +264,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
     { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
     { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -314,6 +336,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -422,6 +453,22 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8c/be/bf49399ad2e788121f595903a56447d4b778d67acbb01ecfc1c6d5cf91f6/pygobject_stubs-2.17.0.tar.gz", hash = "sha256:66884d26974dd7fb99a8bc5972b5bdeb4b7399ecc7ac53913a6cafa6ab21491f", size = 1010510, upload-time = "2026-03-20T17:08:59.656Z" }
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
 
 [[package]]
 name = "python-discovery"


### PR DESCRIPTION
## Description
Add basic tests for all files inside mgallery directory.

## Tech Requirements
- Add pytest to project dependencies.
- Create basic tests, coverage should be around 70%.
- Add to Makefile a command to run tests.