### PR TITLE
MNT-93: Add image tagging script

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Cairo on Ubuntu
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 libraw-dev libcairo2-dev libgirepository1.0-dev gobject-introspection
+          sudo apt-get install -y libraw-dev libcairo2-dev libgirepository-2.0-dev gobject-introspection
 
       - name: Check out the repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -54,3 +54,49 @@ Script setup
    make scan
    make compare
    ```
+
+Image tagging
+----
+
+The `-p` flag sends a local image to a locally running Ollama vision model
+(default `gemma3:12b`) and prints a normalized JSON list of tags to stdout.
+The model is queried via the [`ollama`](https://github.com/ollama/ollama-python)
+Python client with `format="json"` and a low temperature for stable output.
+Tags are lowercased, trimmed, deduplicated, and capped at 20 entries.
+
+Requirements:
+
+- A running Ollama daemon with the `gemma3:12b` model pulled locally:
+  ```bash
+  ollama serve &
+  ollama pull gemma3:12b
+  ```
+
+Environment variables:
+
+- `OLLAMA_HOST` (default `http://localhost:11434`) — Ollama API base URL.
+- `OLLAMA_MODEL` (default `gemma3:12b`) — vision model to use.
+
+Examples:
+
+```bash
+# Tag a single image with the default model
+uv run mgallery.py -p /path/to/photo.jpg
+
+# Override the model
+uv run mgallery.py -p /path/to/photo.jpg -m llama3.2-vision:11b
+```
+
+Sample output (machine-readable JSON, ready to pipe into another tool):
+
+```json
+{"tags": ["sunset", "beach", "sea", "orange sky", "horizon"]}
+```
+
+The script fails with a clear error message on stderr and a non-zero exit
+code when:
+
+- the image file does not exist;
+- Ollama is not running at `OLLAMA_HOST`;
+- the requested model is not installed locally;
+- the model returns a response that cannot be parsed as the expected JSON.

--- a/mgallery.py
+++ b/mgallery.py
@@ -58,6 +58,20 @@ parser.add_argument(
     default=False,
     help="Create thumbnails for duplicated images",
 )
+parser.add_argument(
+    "-p",
+    "--path",
+    type=str,
+    default=None,
+    help="Tag a local image with a local Ollama vision model and print tags as JSON",
+)
+parser.add_argument(
+    "-m",
+    "--model",
+    type=str,
+    default=None,
+    help="Ollama vision model to use for tagging (default: gemma3:12b, or $OLLAMA_MODEL)",
+)
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -90,5 +104,9 @@ if __name__ == "__main__":
         from mgallery.services.thumbnails import run_thumbnails
 
         run_thumbnails()
+    elif args.path:
+        from mgallery.tag import DEFAULT_MODEL, run_tag
+
+        run_tag(image_path=args.path, model=args.model or DEFAULT_MODEL)
     else:
         parser.print_help()

--- a/mgallery/tag.py
+++ b/mgallery/tag.py
@@ -1,0 +1,147 @@
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import ollama
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+DEFAULT_MODEL = os.getenv("OLLAMA_MODEL", "gemma3:12b")
+
+MIN_TAGS = 5
+MAX_TAGS = 20
+
+PROMPT = """
+Analyze this image and return only a JSON object in the format:
+{"tags": ["tag1", "tag2", "tag3"]}
+
+Rules:
+- Output only JSON.
+- Tags must be short noun phrases.
+- Use 5 to 15 tags.
+- Include visible objects, scene type, style, and mood when relevant.
+- Do not include explanations.
+""".strip()
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+class TaggingError(Exception):
+    """Raised when image tagging cannot be completed."""
+
+
+def normalize_tags(tags: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for tag in tags:
+        if not isinstance(tag, str):
+            continue
+        cleaned = tag.strip().lower()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        result.append(cleaned)
+        if len(result) >= MAX_TAGS:
+            break
+    return result
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    if not text:
+        raise TaggingError("Model returned empty response")
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        match = _FENCE_RE.search(text)
+        if not match:
+            raise TaggingError(f"Model returned non-JSON response: {text!r}") from None
+        try:
+            data = json.loads(match.group(1))
+        except json.JSONDecodeError as e:
+            raise TaggingError(f"Model returned invalid JSON: {text!r}") from e
+
+    if not isinstance(data, dict):
+        raise TaggingError(f"Model response is not a JSON object: {data!r}")
+
+    return data
+
+
+def check_ollama_available(client: ollama.Client, model: str = DEFAULT_MODEL, host: str = DEFAULT_HOST) -> None:
+    try:
+        response = client.list()
+    except ConnectionError as e:
+        raise TaggingError(f"Ollama is not running at {host}: {e}") from e
+    except ollama.ResponseError as e:
+        raise TaggingError(f"Ollama request failed: {e}") from e
+
+    installed = {m.model for m in response.models if m.model}
+    if model not in installed:
+        available = ", ".join(sorted(installed)) or "(none)"
+        raise TaggingError(f"Model '{model}' is not available. Installed models: {available}")
+
+
+def generate_tags(
+    image_path: str | Path,
+    model: str = DEFAULT_MODEL,
+    host: str = DEFAULT_HOST,
+) -> list[str]:
+    path = Path(image_path)
+    if not path.is_file():
+        raise TaggingError(f"Image file does not exist: {image_path}")
+
+    client = ollama.Client(host=host)
+    check_ollama_available(client, model=model, host=host)
+
+    try:
+        response = client.chat(
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": PROMPT,
+                    "images": [str(path)],
+                }
+            ],
+            format="json",
+            options={"temperature": 0.2},
+        )
+    except ConnectionError as e:
+        raise TaggingError(f"Ollama is not running at {host}: {e}") from e
+    except ollama.ResponseError as e:
+        raise TaggingError(f"Ollama request failed: {e}") from e
+
+    content = response.message.content or ""
+    data = extract_json(content)
+
+    raw_tags = data.get("tags")
+    if not isinstance(raw_tags, list):
+        raise TaggingError(f"Model response is missing a 'tags' list: {data!r}")
+
+    tags = normalize_tags(raw_tags)
+    if len(tags) < MIN_TAGS:
+        logger.warning(f"Model returned only {len(tags)} tags (minimum is {MIN_TAGS})")
+
+    logger.info(f"Generated {len(tags)} tags for {image_path}")
+    return tags
+
+
+def run_tag(
+    image_path: str,
+    model: str = DEFAULT_MODEL,
+    host: str = DEFAULT_HOST,
+) -> None:
+    try:
+        tags = generate_tags(image_path=image_path, model=model, host=host)
+    except TaggingError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps({"tags": tags}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "exifread>=3.5.1",
     "humanize>=4.15.0",
     "numpy>=2.4.6",
+    "ollama>=0.4.0",
     "opencv-python>=4.10.0",
     "pillow>=12.2.0",
     "pycairo>=1.29.0",

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -1,0 +1,284 @@
+import importlib
+from unittest.mock import MagicMock, patch
+
+import ollama
+import pytest
+
+from mgallery.tag import (
+    MAX_TAGS,
+    TaggingError,
+    check_ollama_available,
+    extract_json,
+    generate_tags,
+    normalize_tags,
+    run_tag,
+)
+
+
+def _chat_response(content: str | None) -> ollama.ChatResponse:
+    return ollama.ChatResponse(message=ollama.Message(role="assistant", content=content))
+
+
+def _list_response(model_names: list[str]) -> ollama.ListResponse:
+    models = [
+        ollama.ListResponse.Model(model=name, modified_at=None, digest=None, size=None, details=None)
+        for name in model_names
+    ]
+    return ollama.ListResponse(models=models)
+
+
+class TestNormalizeTags:
+    def test_lowercase_and_trim(self):
+        assert normalize_tags(["  SUNSET  ", "Beach"]) == ["sunset", "beach"]
+
+    def test_removes_duplicates(self):
+        assert normalize_tags(["sunset", "Sunset", "SUNSET", "beach"]) == ["sunset", "beach"]
+
+    def test_drops_empty_strings(self):
+        assert normalize_tags(["", "   ", "beach"]) == ["beach"]
+
+    def test_skips_non_strings(self):
+        assert normalize_tags(["beach", 123, None, "sea"]) == ["beach", "sea"]
+
+    def test_caps_at_max_tags(self):
+        tags = [f"tag{i}" for i in range(50)]
+        result = normalize_tags(tags)
+        assert len(result) == MAX_TAGS
+
+    def test_empty_list(self):
+        assert normalize_tags([]) == []
+
+
+class TestExtractJson:
+    def test_plain_json(self):
+        assert extract_json('{"tags": ["a", "b"]}') == {"tags": ["a", "b"]}
+
+    def test_markdown_fenced_json(self):
+        assert extract_json('```json\n{"tags": ["a", "b"]}\n```') == {"tags": ["a", "b"]}
+
+    def test_fenced_no_language(self):
+        assert extract_json('```\n{"tags": ["a", "b"]}\n```') == {"tags": ["a", "b"]}
+
+    def test_empty_response(self):
+        with pytest.raises(TaggingError, match="empty"):
+            extract_json("")
+
+    def test_garbage_response(self):
+        with pytest.raises(TaggingError, match="non-JSON"):
+            extract_json("This is not JSON at all, just prose.")
+
+    def test_fenced_invalid_json(self):
+        with pytest.raises(TaggingError, match="invalid JSON"):
+            extract_json("```json\n{not valid json}\n```")
+
+    def test_top_level_array(self):
+        with pytest.raises(TaggingError, match="not a JSON object"):
+            extract_json('["a", "b"]')
+
+    def test_top_level_null(self):
+        with pytest.raises(TaggingError, match="not a JSON object"):
+            extract_json("null")
+
+
+class TestCheckOllamaAvailable:
+    def test_passes_when_model_installed(self):
+        client = MagicMock()
+        client.list.return_value = _list_response(["gemma3:12b", "llama3:8b"])
+        check_ollama_available(client, model="gemma3:12b", host="http://localhost:11434")
+
+    def test_raises_when_model_missing(self):
+        client = MagicMock()
+        client.list.return_value = _list_response(["llama3:8b"])
+        with pytest.raises(TaggingError, match="not available"):
+            check_ollama_available(client, model="gemma3:12b", host="http://localhost:11434")
+
+    def test_raises_when_no_models(self):
+        client = MagicMock()
+        client.list.return_value = _list_response([])
+        with pytest.raises(TaggingError, match="not available"):
+            check_ollama_available(client, model="gemma3:12b", host="http://localhost:11434")
+
+    def test_connection_error_raises_tagging_error(self):
+        client = MagicMock()
+        client.list.side_effect = ConnectionError("connection refused")
+        with pytest.raises(TaggingError, match="not running"):
+            check_ollama_available(client, model="gemma3:12b", host="http://localhost:11434")
+
+    def test_connection_error_uses_host_in_message(self):
+        client = MagicMock()
+        client.list.side_effect = ConnectionError("connection refused")
+        with pytest.raises(TaggingError, match="http://custom-host:9999"):
+            check_ollama_available(client, model="gemma3:12b", host="http://custom-host:9999")
+
+    def test_response_error_raises_tagging_error(self):
+        client = MagicMock()
+        client.list.side_effect = ollama.ResponseError("server error", 500)
+        with pytest.raises(TaggingError, match="Ollama request failed"):
+            check_ollama_available(client, model="gemma3:12b", host="http://localhost:11434")
+
+    def test_client_without_private_attribute_still_raises_tagging_error(self):
+        client = MagicMock(spec=["list"])
+        client.list.side_effect = ConnectionError("connection refused")
+        with pytest.raises(TaggingError, match="not running"):
+            check_ollama_available(client, model="gemma3:12b", host="http://localhost:11434")
+
+
+class TestGenerateTags:
+    def test_missing_file_raises(self, tmp_path):
+        missing = tmp_path / "nope.jpg"
+        with pytest.raises(TaggingError, match="does not exist"):
+            generate_tags(image_path=str(missing))
+
+    @patch("mgallery.tag.check_ollama_available")
+    @patch("mgallery.tag.ollama.Client")
+    def test_valid_response_returns_tags(self, mock_client_cls, mock_check, tmp_path):
+        image = tmp_path / "photo.jpg"
+        image.write_bytes(b"\xff\xd8\xff")
+        mock_client = MagicMock()
+        mock_client.list.return_value = _list_response(["gemma3:12b"])
+        mock_client.chat.return_value = _chat_response('{"tags": ["Sunset", "Beach", "Sea", "Sky", "Horizon"]}')
+        mock_client_cls.return_value = mock_client
+
+        result = generate_tags(image_path=str(image), model="gemma3:12b", host="http://localhost:11434")
+
+        assert result == ["sunset", "beach", "sea", "sky", "horizon"]
+        mock_check.assert_called_once()
+        call_kwargs = mock_client.chat.call_args.kwargs
+        assert call_kwargs["model"] == "gemma3:12b"
+        assert call_kwargs["format"] == "json"
+        assert call_kwargs["options"]["temperature"] == 0.2
+        assert call_kwargs["messages"][0]["images"] == [str(image)]
+
+    @patch("mgallery.tag.check_ollama_available")
+    @patch("mgallery.tag.ollama.Client")
+    def test_markdown_fenced_response(self, mock_client_cls, mock_check, tmp_path):
+        image = tmp_path / "photo.jpg"
+        image.write_bytes(b"\xff\xd8\xff")
+        mock_client = MagicMock()
+        mock_client.list.return_value = _list_response(["gemma3:12b"])
+        mock_client.chat.return_value = _chat_response(
+            '```json\n{"tags": ["Forest", "Mist", "Mood", "Green", "Trees"]}\n```'
+        )
+        mock_client_cls.return_value = mock_client
+
+        result = generate_tags(image_path=str(image))
+
+        assert result == ["forest", "mist", "mood", "green", "trees"]
+
+    @patch("mgallery.tag.check_ollama_available")
+    @patch("mgallery.tag.ollama.Client")
+    def test_connection_error_raises(self, mock_client_cls, mock_check, tmp_path):
+        image = tmp_path / "photo.jpg"
+        image.write_bytes(b"\xff\xd8\xff")
+        mock_check.side_effect = None
+        mock_client = MagicMock()
+        mock_client.chat.side_effect = ConnectionError("connection refused")
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(TaggingError, match="not running"):
+            generate_tags(image_path=str(image))
+
+    @patch("mgallery.tag.check_ollama_available")
+    @patch("mgallery.tag.ollama.Client")
+    def test_response_error_raises(self, mock_client_cls, mock_check, tmp_path):
+        image = tmp_path / "photo.jpg"
+        image.write_bytes(b"\xff\xd8\xff")
+        mock_check.side_effect = None
+        mock_client = MagicMock()
+        mock_client.chat.side_effect = ollama.ResponseError("model not found", 404)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(TaggingError, match="Ollama request failed"):
+            generate_tags(image_path=str(image))
+
+    @patch("mgallery.tag.check_ollama_available")
+    @patch("mgallery.tag.ollama.Client")
+    def test_invalid_json_raises(self, mock_client_cls, mock_check, tmp_path):
+        image = tmp_path / "photo.jpg"
+        image.write_bytes(b"\xff\xd8\xff")
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _chat_response("Sorry, I cannot help with that.")
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(TaggingError, match="non-JSON"):
+            generate_tags(image_path=str(image))
+
+    @patch("mgallery.tag.check_ollama_available")
+    @patch("mgallery.tag.ollama.Client")
+    def test_none_content_raises(self, mock_client_cls, mock_check, tmp_path):
+        image = tmp_path / "photo.jpg"
+        image.write_bytes(b"\xff\xd8\xff")
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _chat_response(None)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(TaggingError, match="empty"):
+            generate_tags(image_path=str(image))
+
+    @patch("mgallery.tag.check_ollama_available")
+    @patch("mgallery.tag.ollama.Client")
+    def test_missing_tags_key_raises(self, mock_client_cls, mock_check, tmp_path):
+        image = tmp_path / "photo.jpg"
+        image.write_bytes(b"\xff\xd8\xff")
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _chat_response('{"labels": ["x"]}')
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(TaggingError, match="tags"):
+            generate_tags(image_path=str(image))
+
+    @patch("mgallery.tag.check_ollama_available")
+    @patch("mgallery.tag.ollama.Client")
+    def test_tags_not_a_list_raises(self, mock_client_cls, mock_check, tmp_path):
+        image = tmp_path / "photo.jpg"
+        image.write_bytes(b"\xff\xd8\xff")
+        mock_client = MagicMock()
+        mock_client.chat.return_value = _chat_response('{"tags": "sunset"}')
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(TaggingError, match="tags"):
+            generate_tags(image_path=str(image))
+
+
+class TestRunTag:
+    @patch("mgallery.tag.generate_tags")
+    def test_prints_json_on_success(self, mock_generate, capsys, tmp_path):
+        mock_generate.return_value = ["sunset", "beach"]
+        run_tag(image_path=str(tmp_path / "photo.jpg"))
+        captured = capsys.readouterr()
+        assert captured.out.strip() == '{"tags": ["sunset", "beach"]}'
+        assert captured.err == ""
+
+    @patch("mgallery.tag.generate_tags")
+    def test_exits_with_error_message_on_tagging_error(self, mock_generate, capsys, tmp_path):
+        mock_generate.side_effect = TaggingError("Model 'gemma3:12b' is not available")
+        with pytest.raises(SystemExit) as exc_info:
+            run_tag(image_path=str(tmp_path / "photo.jpg"))
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Error: Model 'gemma3:12b' is not available" in captured.err
+        assert captured.out == ""
+
+
+class TestDefaultModelEnvVar:
+    def test_default_model_respects_ollama_model_env(self, monkeypatch):
+        from mgallery import tag
+
+        monkeypatch.setenv("OLLAMA_MODEL", "custom-model:7b")
+        reloaded = importlib.reload(tag)
+        try:
+            assert reloaded.DEFAULT_MODEL == "custom-model:7b"
+        finally:
+            monkeypatch.delenv("OLLAMA_MODEL")
+            importlib.reload(reloaded)
+
+    def test_default_host_respects_ollama_host_env(self, monkeypatch):
+        from mgallery import tag
+
+        monkeypatch.setenv("OLLAMA_HOST", "http://custom-host:9999")
+        reloaded = importlib.reload(tag)
+        try:
+            assert reloaded.DEFAULT_HOST == "http://custom-host:9999"
+        finally:
+            monkeypatch.delenv("OLLAMA_HOST")
+            importlib.reload(reloaded)

--- a/uv.lock
+++ b/uv.lock
@@ -17,12 +17,42 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
 ]
 
 [[package]]
@@ -97,11 +127,50 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
     { url = "https://files.pythonhosted.org/packages/6d/5c/a485a36e87df8d8fd0632ee01511244f5156a20ed3746cc6599340326395/greenlet-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e", size = 235499, upload-time = "2026-05-20T13:12:42.028Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -120,6 +189,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -240,6 +318,7 @@ dependencies = [
     { name = "exifread" },
     { name = "humanize" },
     { name = "numpy" },
+    { name = "ollama" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "psycopg2-binary" },
@@ -266,6 +345,7 @@ requires-dist = [
     { name = "exifread", specifier = ">=3.5.1" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "numpy", specifier = ">=2.4.6" },
+    { name = "ollama", specifier = ">=0.4.0" },
     { name = "opencv-python", specifier = ">=4.10.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
@@ -322,6 +402,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
     { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
     { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+]
+
+[[package]]
+name = "ollama"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
 ]
 
 [[package]]
@@ -522,6 +615,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -695,6 +829,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image tagging functionality using Ollama vision models via `--path` flag to tag local images
  * Added `--model` flag to specify which Ollama vision model to use
  * Tags are automatically normalized, deduplicated, and returned as machine-readable JSON output

* **Documentation**
  * Added "Image tagging" section to README with setup instructions, environment variables, example commands, and sample output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->